### PR TITLE
Changed `VC` to `ViewController`.

### DIFF
--- a/Samples.playground/Pages/Counter, No Interaction.xcplaygroundpage/Contents.swift
+++ b/Samples.playground/Pages/Counter, No Interaction.xcplaygroundpage/Contents.swift
@@ -29,7 +29,7 @@ extension Counter: RootComponent {
     }
     
     //: Our view controller consists of a single label with the current count
-    var viewController: VC<Message> {
+    var viewController: ViewController<Message> {
         return .viewController(.label(text: "Count: \(count)"))
     }
     


### PR DESCRIPTION
I think this is a typo and `VC` was intended to refer to the `ViewController` enum in the VirtualViews framework. This works for me in Xcode 9.0 beta.
<img width="1212" alt="screenshot" src="https://user-images.githubusercontent.com/436192/28142097-6108938a-672d-11e7-93c8-4510d4262a67.png">