### PR TITLE
Small fixes to the playground pages

### DIFF
--- a/Samples.playground/Pages/Counter with Interaction.xcplaygroundpage/Contents.swift
+++ b/Samples.playground/Pages/Counter with Interaction.xcplaygroundpage/Contents.swift
@@ -1,6 +1,7 @@
 import UIKit
 import TodosFramework
 import VirtualViews
+import PlaygroundSupport
 
 //: We'll re-use our previous state, but will add interaction to it.
 struct Counter {
@@ -32,7 +33,7 @@ extension Counter: RootComponent {
         return .viewController(.stackView(views: [
             .label(text: "Count: \(count)"),
             .button(text: "Increment", onTap: .increment)
-            ])
+            ]))
     }
     
     var subscriptions: [Subscription<Message>] {
@@ -43,7 +44,7 @@ extension Counter: RootComponent {
 //: The only way to change the state is through sending a message. Because the `Driver` will take care of updating the view hierarchy, it is not possible to forget to update your views when the state changes. This all happens automatically.
 
 let driver = Driver(Counter(count: 0))
-PlaygroundPage.current.liveView = driver.viewController.view
+PlaygroundPage.current.liveView = driver.viewController
 
 extension Counter.Message: Equatable {
     static func ==(lhs: Counter.Message, rhs: Counter.Message) -> Bool {

--- a/Samples.playground/Pages/Counter, No Interaction.xcplaygroundpage/Contents.swift
+++ b/Samples.playground/Pages/Counter, No Interaction.xcplaygroundpage/Contents.swift
@@ -57,5 +57,4 @@ extension Counter.Message: Equatable {
     }
 }
 
-//: TODO: this doesn't work on my current Xcode, but will probably work in the future again:
-//: `PlaygroundPage.current.liveView = driver.viewController`
+PlaygroundPage.current.liveView = driver.viewController


### PR DESCRIPTION
`Counter, No Interaction` page:
* The `liveView` now works, at least with Xcode 9 beta 6

`Counter with Interaction` page:
* Add missing import and close paren
* Fix the `liveView` to use the `viewController` (instead of `.view`)